### PR TITLE
Add ititial cypress testing

### DIFF
--- a/cypress/e2e/individual_movie_spec.cy.js
+++ b/cypress/e2e/individual_movie_spec.cy.js
@@ -1,19 +1,74 @@
-describe('As a user, when I click on a movie, I’m shown additional details about that movie', () => {
+describe('As a user, when I click on a movie, I am shown additional details about that movie', () => {
 
   beforeEach(() => {
-    cy.visit('http://localhost:3000/')
+    cy
+    .visit('http://localhost:3000')
+    .get('[id="694919"]')
+    .click()
+    .url().should('eq','http://localhost:3000/694919' )
+    // .visit('http://localhost:3000/694919')
+    .intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2//movies/694919', {
+      statusCode: 201,
+      body: {
+          id: 694919,
+          title: "Money Plane",
+          poster_path: "https://image.tmdb.org/t/p/original//6CoRTJTmijhBLJTUNoVSUNxZMEI.jpg",
+          backdrop_path: "https://image.tmdb.org/t/p/original//pq0JSpwyT2URytdFG0euztQPAyR.jpg",
+          release_date: "2020-09-29",
+          overview: "A professional thief with $40 million in debt and his family's life on the line must commit one final heist - rob a futuristic airborne casino filled with the world's most dangerous criminals.",
+          genres: [
+          "Action"
+          ],
+          budget: 0,
+          revenue: 0,
+          runtime: 82,
+          tagline: "",
+          average_rating: 6.875
+      }})
+      .visit('http://localhost:3000/694919')
   })
 
-  it.skip('should display an error message (500 status code) if the individual movie is unable to render', () => {
-    cy.get('.error-text').should('contain','Movies cannot load. Please try again' )
+  it('should display an error message (500 status code) if the individual movie is unable to render', () => {
+    cy
+     .intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2//movies/694919', 
+     {statusCode: 500, body: {message: `Movies cannot load. Please try again.` }})
+  })
+  
+  it('should display the navbar with the application logo and home button', () => {
+      cy
+       .get('.navBar').should('exist')
+       .get('.logo').should('exist')
+    
   })
 
-  it.skip('should be able to see all the details about the movie they clicked on', () => {
-    cy.get('.error-text').should('contain','Movies cannot load. Please try again' )
-  })
+  it.skip('should render all the details about the movie they clicked on', () => {
+    cy
+      // .intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2//movies/694919', {
+      //   statusCode: 201,
+      //   body: {
+      //       id: 694919,
+      //       title: "Money Plane",
+      //       poster_path: "https://image.tmdb.org/t/p/original//6CoRTJTmijhBLJTUNoVSUNxZMEI.jpg",
+      //       backdrop_path: "https://image.tmdb.org/t/p/original//pq0JSpwyT2URytdFG0euztQPAyR.jpg",
+      //       release_date: "2020-09-29",
+      //       overview: "A professional thief with $40 million in debt and his family's life on the line must commit one final heist - rob a futuristic airborne casino filled with the world's most dangerous criminals.",
+      //       genres: [
+      //       "Action"
+      //       ],
+      //       budget: 0,
+      //       revenue: 0,
+      //       runtime: 82,
+      //       tagline: "",
+      //       average_rating: 6.875
+      //   }})
+      .url().should('include', '/694919')
+      .get('h1.individual-movie-title').contains("Money Plane")
+      .get('.individual-movie-img').should('have.attr', 'https://image.tmdb.org/t/p/original//pq0JSpwyT2URytdFG0euztQPAyR.jpg')
+      .get('average_rating').contains('6.6')
+      .get('id').contains(694919)
+       //.get('.home-button').click()
+      
 
-  it.skip('should display the navbar with the application logo and home button', () => {
-    cy.get('.error-text').should('contain','Movies cannot load. Please try again' )
   })
 
   it.skip('should no longer display the dashboard that displays all the movies', () => {

--- a/cypress/e2e/movies_container_spec.cy.js
+++ b/cypress/e2e/movies_container_spec.cy.js
@@ -1,28 +1,26 @@
 describe('As a user, when I load the application, I can see a collection of movies', () => {
 
   beforeEach(() => {
-    //intercept on page load w/stub.  return card data
-    //refrence a dummy data file
-    //stubbing is returned w/dummy data
     cy.visit('http://localhost:3000/')
   })
 
-  it.skip('should display an error message (500 status code) if movies are unable to be displayed on the screen', () => {
-    cy.get('.error-text').should('contain','Movies cannot load. Please try again' )
-    //intercept w/stub (return code 500)
-    // intercept? 
-    //200 if you get movies back
+  it('should display an error message (500 status code) if movies are unable to be displayed on the screen', () => {
+    cy
+      .intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', 
+      {statusCode: 500, body: { message: `Movies cannot load. Please try again.`}} ) 
   })
 
   it('should display all movies each with a title, movie poster, and rating', () => {
-    cy.get('.movie-container').should('exist')
-    cy.get('.movie-card').should('exist')
-    cy.get('.card-img').should('exist')
-    cy.get('.titles').should('exist')
-    cy.get('.rating-container').should('exist')
-    cy.get('.tomatillo-image').should('exist')
-    cy.get('.ratings').should('exist')
-    // intercept?
+    cy
+      .get('img').should('be.visible')
+      .get('.movie-container').should('exist')
+      .get('.movie-card').should('exist').should('have.length', 40)
+      .get('.card-img').should('be.visible')
+      .get('.titles').should('be.visible').should('have.length', 40)
+      .get('.rating-container').should('exist')
+      .get('.tomatillo-image').should('be.visible')
+      .get('.ratings').should('have.length', 40)
+    
   })
 
   it.skip('should not display details for an individual movie', () => {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -45,7 +45,9 @@ class App extends Component {
   }
 
   returnHome = () => {
-    this.setState({ selectedMovie: {}, isHome: true })
+    this.setState({ 
+      // selectedMovie: {}, 
+      isHome: true })
   }
 
   render() {
@@ -59,7 +61,7 @@ class App extends Component {
           // <img />
         }
         {this.state.error && 
-          <h2 className='error-text'>There was an error: {this.state.error}. Movies cannot load. Please try again.</h2>}
+          <h2 className='error-text'>{this.state.error}Movies cannot load. Please try again.</h2>}
         <Route exact path='/'
           render={() => <MoviesContainer movies={this.state.movies} handleClick={this.handleClick}/> } />
         <Route exact path='/:id' 


### PR DESCRIPTION
# Description

--we have decided to move our Onclick fetch over to our individualMovie file in order to take the fetch call off of the button so when a user opens an individual movie into a new browser, the information will persist. 


## Type of change

- [ x] Bug fix (will need to fix this issue)
- [ ] New feature (adds functionality)
- [ x] Refactor


